### PR TITLE
Update the test, add unit test for contract sig situation

### DIFF
--- a/packages/safe-scroll-keystore/test/SafeRemoteKeystoreModule.spec.ts
+++ b/packages/safe-scroll-keystore/test/SafeRemoteKeystoreModule.spec.ts
@@ -2,7 +2,7 @@ import { loadFixture } from '@nomicfoundation/hardhat-network-helpers'
 import { expect } from 'chai'
 import { JsonRpcProvider, parseEther } from 'ethers'
 
-import { execKeystoreTransaction, execKeystoreTransactionNested} from './helpers/execKeystoreTransaction'
+import execKeystoreTransaction, { execKeystoreTransactionNested } from './helpers/execKeystoreTransaction'
 import execTransaction from './helpers/execSafeTransaction'
 import setup, { nestedSetup } from './helpers/setup'
 import { HardhatEthersProvider } from '@nomicfoundation/hardhat-ethers/internal/hardhat-ethers-provider'

--- a/packages/safe-scroll-keystore/test/SafeRemoteKeystoreModule.spec.ts
+++ b/packages/safe-scroll-keystore/test/SafeRemoteKeystoreModule.spec.ts
@@ -127,7 +127,7 @@ describe('SafeRemoteKeystoreModule', () => {
     })
 
     it('Executes ETH transfer via SafeRemoteKeystore module with Nested Contract Signature', async () => {
-        const { provider, safeL1, safeNestedL1, safeL2, safeRemoteKeystoreModule, owner1L1, owner2L1, ownerL2 } = await loadFixture(nestedSetup)
+        const { provider, safeNestedL1, safeL1, safeL2, safeRemoteKeystoreModule, owner1L1, owner2L1, ownerL2 } = await loadFixture(nestedSetup)
 
         const safeL2Address = await safeL2.getAddress()
         const safeRemoteKeystoreModuleAddress = await safeRemoteKeystoreModule.getAddress()
@@ -142,7 +142,7 @@ describe('SafeRemoteKeystoreModule', () => {
         const amount = parseEther("0.1")
         await execKeystoreTransactionNested(safeRemoteKeystoreModule, {
             safeL2: safeL2Address,
-            safeNestedL1: safeNestedL1,
+            safeL1: safeL1,
             to: RECIPIENT_ADDR,
             value: amount,
             data: "0x",

--- a/packages/safe-scroll-keystore/test/helpers/execKeystoreTransaction.ts
+++ b/packages/safe-scroll-keystore/test/helpers/execKeystoreTransaction.ts
@@ -1,7 +1,11 @@
 import { concat, getBytes, solidityPackedKeccak256 } from 'ethers'
 import { SafeRemoteKeystoreModule } from '../../typechain-types'
+import { sign } from 'crypto';
+const CONTRACT_ADDR_PREFIX = "0x000000000000000000000000";
+const CONTRACT_SIG_V = "0x00";
+const CONTRACT_SIG_OFFSET = "0x0000000000000000000000000000000000000000000000000000000000000082";
 
-export default async function execKeystoreTransaction(
+export async function execKeystoreTransaction(
   module: SafeRemoteKeystoreModule,
   {
     safeL2,
@@ -16,10 +20,11 @@ export default async function execKeystoreTransaction(
   const msg = await module.getTxHash(safeL2, to, value, data, operation)
 
   // Sign message with signers L1
-  const signatures = []
+  const signatures: string[] = []
   for (var signer of signersL1) {
-    const signature = await signer.signMessage(getBytes(msg))
-    signatures.push(signature)
+    let signature = await signer.signMessage(getBytes(msg));
+    signatures.push(updateEIP191Sig(signature)) 
+
   }
 
   // Execute transaction
@@ -32,4 +37,66 @@ export default async function execKeystoreTransaction(
     operation,
     concat(signatures)
   )
+}
+
+export async function execKeystoreTransactionNested(
+  module: SafeRemoteKeystoreModule,
+  {
+    safeL2,
+    safeNestedL1,
+    to,
+    value,
+    data,
+    operation,
+    signersL1
+  }: any
+) {
+  // Get message
+  const msg = await module.getTxHash(safeL2, to, value, data, operation)
+
+  // Sign message with signers L1
+  const signatures: string[] = []
+  const signature_owner1 = await signersL1[0].signMessage(getBytes(msg));
+
+  // First we need the signersL1[0] -- owner1L1, to sign the tx, the owner1L1 is the EOA member of SAFE_L1
+  signatures.push(updateEIP191Sig(signature_owner1));
+
+  // Then, we will construct the contract sig for safeNestedL1
+  signatures.push(CONTRACT_ADDR_PREFIX, safeNestedL1);
+  signatures.push(CONTRACT_SIG_OFFSET, CONTRACT_SIG_V);
+  
+  // Set the offset for the following 2 signature
+  signatures.push(CONTRACT_SIG_OFFSET);
+
+  // concat with the sig by owner1L1 & owner2L1
+  for (var signer of signersL1) {
+    let signature = await signer.signMessage(getBytes(msg));
+    signatures.push(updateEIP191Sig(signature))   
+  }
+
+  console.log(signatures)
+  // Execute transaction
+  console.log(`---> SafeKeystoreModule.executeTransaction :: to=${to}, value=${value}, data=${data}, operation=${operation}, signatures=${concat(signatures)}`)
+  return module.executeTransaction(
+    safeL2,
+    to,
+    value,
+    data,
+    operation,
+    concat(signatures)
+  )
+}
+
+function updateEIP191Sig(
+  signature: string
+) {
+  const lastByte = signature.slice(-2);
+  // Since it is a eip191 sig
+  if (lastByte === "1b" || lastByte === "1c") {
+    const modifiedByte = (parseInt(lastByte, 16) + 4).toString(16);
+    signature = signature.slice(0, -2) + modifiedByte.padStart(2, "0");
+    return signature
+  } else {
+    throw new Error("Last byte is not 1b or 1c");
+  }
 }

--- a/packages/safe-scroll-keystore/test/helpers/execKeystoreTransaction.ts
+++ b/packages/safe-scroll-keystore/test/helpers/execKeystoreTransaction.ts
@@ -43,7 +43,7 @@ export async function execKeystoreTransactionNested(
   module: SafeRemoteKeystoreModule,
   {
     safeL2,
-    safeNestedL1,
+    safeL1,
     to,
     value,
     data,
@@ -62,7 +62,7 @@ export async function execKeystoreTransactionNested(
   signatures.push(updateEIP191Sig(signature_owner1));
 
   // Then, we will construct the contract sig for safeNestedL1
-  signatures.push(CONTRACT_ADDR_PREFIX, safeNestedL1);
+  signatures.push(CONTRACT_ADDR_PREFIX, safeL1);
   signatures.push(CONTRACT_SIG_OFFSET, CONTRACT_SIG_V);
   
   // Set the offset for the following 2 signature

--- a/packages/safe-scroll-keystore/test/helpers/execKeystoreTransaction.ts
+++ b/packages/safe-scroll-keystore/test/helpers/execKeystoreTransaction.ts
@@ -5,7 +5,7 @@ const CONTRACT_ADDR_PREFIX = "0x000000000000000000000000";
 const CONTRACT_SIG_V = "0x00";
 const CONTRACT_SIG_OFFSET = "0x0000000000000000000000000000000000000000000000000000000000000082";
 
-export async function execKeystoreTransaction(
+export default async function execKeystoreTransaction(
   module: SafeRemoteKeystoreModule,
   {
     safeL2,

--- a/packages/safe-scroll-keystore/test/helpers/setup.ts
+++ b/packages/safe-scroll-keystore/test/helpers/setup.ts
@@ -93,7 +93,10 @@ export default async function setup() {
   }
 }
 
-
+/// We are going to set a nested multisig account structure on L1:
+/// The multisig account `SAFE_L1` has 2 owners : `owner1L1`(which is a EOA) and `safeNestedL1`(which is another multisig account)
+/// The multisig account `SafeNestedL1` has 2 owners: `owner1L1` and `owner2L1`(which are both EOAs)
+/// Both of the 2 multisig accounts(`SAFE_L1` & `SafeNestedL1`) have a threshold of 2
 export async function nestedSetup() {
   const [owner1L1, owner2L1, ownerL2, deployer, relayer] = await hre.ethers.getSigners()
   const thresholdL1 = "0x02" // 2

--- a/packages/safe-scroll-keystore/test/helpers/setup.ts
+++ b/packages/safe-scroll-keystore/test/helpers/setup.ts
@@ -17,7 +17,7 @@ import { AbiCoder, getBytes, hexlify, keccak256, parseEther, toUtf8Bytes, zeroPa
 
 
 const SAFE_L1 = "0x0000000000000000000000000000000000005aFE"
-
+const SAFE_NESTED_L1 = "0x0000000000000000000000000000000000006bEF"
 export default async function setup() {
   const [owner1L1, owner2L1, ownerL2, deployer, relayer] = await hre.ethers.getSigners()
   const thresholdL1 = "0x02" // 2
@@ -79,6 +79,98 @@ export default async function setup() {
     provider: owner1L1.provider,
     // safes
     safeL1: SAFE_L1,
+    safeL2,
+    // singletons
+    safeRemoteKeystoreModule,
+    safeDisableLocalKeystoreGuard,
+    l1sload,
+    // ERC20 token
+    token,
+    // signers
+    owner1L1,
+    owner2L1,
+    ownerL2
+  }
+}
+
+
+export async function nestedSetup() {
+  const [owner1L1, owner2L1, ownerL2, deployer, relayer] = await hre.ethers.getSigners()
+  const thresholdL1 = "0x02" // 2
+  const thresholdL2 = "0x01"
+
+  const { safeProxyFactoryAddress, safeMastercopyAddress } = await deploySingletons(deployer)
+
+  // Create Safe
+  const safeL2Address = await deploySafeProxy(safeProxyFactoryAddress, safeMastercopyAddress, [ownerL2.address], thresholdL2, deployer)
+
+  // Deploy Test/Mocks contracts
+  const l1Blocks = await deployMockedL1Blocks(deployer)
+  const l1sload = await deployMockedL1Sload(deployer)
+  const token = await deployTestToken(deployer)
+
+  // Configure Mocks
+  const abiencoder = AbiCoder.defaultAbiCoder()
+  const SENTINEL_ADDR = "0x0000000000000000000000000000000000000001"
+  await l1sload.set(SAFE_L1, zeroPadValue("0x04", 32), zeroPadValue(thresholdL1, 32));
+  await l1sload.set(
+    SAFE_L1,
+    keccak256(abiencoder.encode(["address", "uint256"], [SENTINEL_ADDR, zeroPadValue("0x02", 32)])),
+    zeroPadValue(owner1L1.address, 32));
+  await l1sload.set(
+    SAFE_L1,
+    keccak256(abiencoder.encode(["address", "uint256"], [owner1L1.address, zeroPadValue("0x02", 32)])),
+    zeroPadValue(SAFE_NESTED_L1, 32));
+  await l1sload.set(
+    SAFE_L1,
+    keccak256(abiencoder.encode(["address", "uint256"], [SAFE_NESTED_L1, zeroPadValue("0x02", 32)])),
+    zeroPadValue(SENTINEL_ADDR, 32));
+  // set the nested L1
+  await l1sload.set(SAFE_NESTED_L1, zeroPadValue("0x04", 32), zeroPadValue(thresholdL1, 32));
+  await l1sload.set(
+    SAFE_NESTED_L1,
+    keccak256(abiencoder.encode(["address", "uint256"], [SENTINEL_ADDR, zeroPadValue("0x02", 32)])),
+    zeroPadValue(owner1L1.address, 32));
+  await l1sload.set(
+    SAFE_NESTED_L1,
+    keccak256(abiencoder.encode(["address", "uint256"], [owner1L1.address, zeroPadValue("0x02", 32)])),
+    zeroPadValue(owner2L1.address, 32));
+  await l1sload.set(
+    SAFE_NESTED_L1,
+    keccak256(abiencoder.encode(["address", "uint256"], [owner2L1.address, zeroPadValue("0x02", 32)])),
+    zeroPadValue(SENTINEL_ADDR, 32));
+  
+
+  // Deploy Keystore module
+  const SafeRemoteKeystoreModuleContract = await ethers.getContractFactory("SafeRemoteKeystoreModule");
+  const safeRemoteKeystoreModule = await SafeRemoteKeystoreModuleContract.deploy();
+
+  // Deploy Keystore guard
+  const SafeDisableLocalKeystoreGuardContract = await ethers.getContractFactory("SafeDisableLocalKeystoreGuard");
+  const safeDisableLocalKeystoreGuard = await SafeDisableLocalKeystoreGuardContract.deploy(safeRemoteKeystoreModule);
+
+  // Configure Keystore module
+  await safeRemoteKeystoreModule.initialize(l1Blocks, l1sload, safeDisableLocalKeystoreGuard)
+
+  // Connect Safe
+  //const safeL1 = ISafe__factory.connect(safeL1Address, relayer)
+  const safeL2 = ISafe__factory.connect(safeL2Address, relayer)
+
+  // fund the safe (1 ETH)
+  await ownerL2.sendTransaction({
+    to: safeL2Address,
+    value: parseEther('1'),
+  })
+
+  // fund the safe (1000 TT)
+  await token.transfer(safeL2Address, 1000)
+
+  return {
+    //provider
+    provider: owner1L1.provider,
+    // safes
+    safeL1: SAFE_L1,
+    safeNestedL1: SAFE_NESTED_L1,
     safeL2,
     // singletons
     safeRemoteKeystoreModule,


### PR DESCRIPTION
- Update the original 4 test, the signing method of EOA is EIP191 signature, so we should add `4` to the signature's `v` part (the same with `GnosisSafe.sol`)
- Add a new test function for Contract Signature Situation